### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ddwrt-companion.app
+  annotations:
+    github.com/project-slug: lemra-org/ddwrt-companion.app
+spec:
+  type: other
+  lifecycle: unknown
+  owner: lemra-org


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Red Hat Developer Hub (rm3l) software catalog](https://backstage-developer-hub-my-ns.apps-crc.testing).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).